### PR TITLE
Load

### DIFF
--- a/lib/binary_search_tree.rb
+++ b/lib/binary_search_tree.rb
@@ -33,6 +33,8 @@ class BinarySearchTree
           if !title.nil?
             parent_node.set_child(node)
             depth += 1
+          elsif parent_node.info[:score] != score
+            depth += 1
           end
           return depth
         else

--- a/lib/binary_search_tree.rb
+++ b/lib/binary_search_tree.rb
@@ -103,7 +103,7 @@ class BinarySearchTree
 
     if current_node.left_child
       sorted_list << sort(current_node.left_child)
-
+      sorted_list << element if !current_node.right_child
     end
 
     if current_node.right_child
@@ -112,6 +112,19 @@ class BinarySearchTree
     end
 
     return sorted_list.flatten
+  end
+
+  def load
+
+    file = File.open("movies.txt")
+    file_data = file.readlines.map(&:chomp)
+    file.close
+
+    file_data.each do |line|
+      split_line = line.split(%r{,\s*})
+      insert(split_line[0].to_i, split_line[1])
+    end
+
   end
 
 end

--- a/movies.txt
+++ b/movies.txt
@@ -1,0 +1,6 @@
+34, Hannibal Buress: Comedy Camisado
+63, Meet My Valentine
+22, Experimenter
+84, French Dirty
+41, Love
+10, I Love You Phillip Morris

--- a/test/binary_search_tree_test.rb
+++ b/test/binary_search_tree_test.rb
@@ -99,9 +99,15 @@ class BinarySearchTreeTest < Minitest::Test
   def test_load
     tree = BinarySearchTree.new
     tree.load
-    require "pry"; binding.pry
+    expected_max = {"French Dirty"=>84}
+    expected_min = {"I Love You Phillip Morris"=>10}
 
     assert_equal 34, tree.root.info[:score]
+    assert_equal expected_max, tree.max
+    assert_equal expected_min, tree.min
+    assert tree.include?(22)
+    refute tree.include?(21)
+    assert_equal 2, tree.depth_of(41)
   end
 
 end

--- a/test/binary_search_tree_test.rb
+++ b/test/binary_search_tree_test.rb
@@ -96,4 +96,12 @@ class BinarySearchTreeTest < Minitest::Test
     assert_equal expected, @tree.sort
   end
 
+  def test_load
+    tree = BinarySearchTree.new
+    tree.load
+    require "pry"; binding.pry
+
+    assert_equal 34, tree.root.info[:score]
+  end
+
 end


### PR DESCRIPTION
-Add #load
-Fix #sort - sort wasn't adding nodes that had only a left child
-Modify #depth_of to account for depth of scores that aren't present in tree